### PR TITLE
Handle Unicode characters in file names

### DIFF
--- a/unrpa
+++ b/unrpa
@@ -59,7 +59,7 @@ class UnRPA:
 		paths = index.keys()
 		paths.sort()
 		for path in paths:
-			print(path)
+			print(path.encode('utf-8'))
 
 	def extract_file(self, name, data):
 		if self.verbose > 1:


### PR DESCRIPTION
Fixes

Traceback (most recent call last):
  File "./unrpa", line 163, in <module>
    unarchiver.list_files()
  File "./unrpa", line 62, in list_files
    print(path)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 11-15: ordinal not in range(128)

if file names contain non-ASCII characters