### PR TITLE
Fix wrong offset and key from line substring

### DIFF
--- a/unrpa
+++ b/unrpa
@@ -91,8 +91,9 @@ class UnRPA:
 		if self.version == 3:
 			with open(self.archive, "rb") as f:
 				l = f.readline()
-				offset = int(l[8:24], 16)
-				key = int(l[25:33], 16)
+				parts = l.split()
+				offset = int(parts[1], 16)
+				key = int(parts[2], 16)
 				f.seek(offset)
 				index = pickle.loads(f.read().decode("zlib"))
 				index = self.deobfuscate_index(index, key)


### PR DESCRIPTION
Some versions have a longer zero pad string in the first line causing errors, Ex:
Works with:
RPA-3.0 0000000010678236 42424242
Error with:
RPA-3.0 00000000000000000000000017e6d450 42424242

Fixed splitting on whitespaces instead of subindex